### PR TITLE
Fix a bug in Execom

### DIFF
--- a/src/components/SeemoreMembers.js
+++ b/src/components/SeemoreMembers.js
@@ -3,6 +3,10 @@ import Nav from './Nav';
 import CardsUIcont from './CardsUIcont';
 
 class SeemoreMembers extends React.Component {
+    componentDidMount() {
+        window.scrollTo(0, 0);
+    }
+
     render() {
         return (
             <div>


### PR DESCRIPTION
On clicking Members and Contacts button SeemoreMembers used to render in a partially scrolled state. Now it renders scrolled to the top.🙂